### PR TITLE
No need to pull docker image before run

### DIFF
--- a/1a-tectonic-docker/.travis.yml
+++ b/1a-tectonic-docker/.travis.yml
@@ -4,7 +4,6 @@ services: docker
 
 script:
   # We use the docker image from https://hub.docker.com/r/dxjoke/tectonic-docker/
-  - docker pull dxjoke/tectonic-docker
   # Compiling only main.tex:
   - docker run --mount src=$TRAVIS_BUILD_DIR/src,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic main.tex"
   # Compiling multiple files as well as using biber:


### PR DESCRIPTION
Docker run automatically pulls if the image is not available (locally).

I figured it out by accident, when I was testing another tag of the image on the build and it pulled two different images but only ran once.

So I thought I fix it upstream as well. 😄  Just a tiny "optimization".  